### PR TITLE
Update Util.js

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -30,11 +30,10 @@ class Util {
             filters.unshift({ name: fileTypes.substr(1), extensions: [fileTypes.substr(1).toLowerCase()] });
         }
 
-        let filePath = await new Promise((res) => {
-            dialog.showSaveDialog({
+        //#6 fix empty Promise with async implementation in newer atom versions.
+        let filePath = dialog.showSaveDialogSync({
                 defaultPath: defaultPath,
                 filters: filters,
-            }, res);
         });
 
         return filePath;


### PR DESCRIPTION
Fixes #6 .

Changes proposed in this pull request:
- using showSaveDialogSync instead of showSaveDialog will return the proper file path, as the Promise of showSaveDialog didn't resolve the file path in current atom versions.

Fixes # .

Changes proposed in this pull request:
-
-
-
